### PR TITLE
fix: container extension doc mentions also containerd and crio

### DIFF
--- a/targetTypes/com.steadybit.extension_container.container/summary.mdx
+++ b/targetTypes/com.steadybit.extension_container.container/summary.mdx
@@ -1,8 +1,12 @@
 # Discovery of Container Targets
 
-### Docker
+### Supported Container Runtimes
 
-The agent discovers any running container communication with the docker daemon using `/var/run/docker.sock`. You can configure a different docker socket by setting the environment variable `STEADYBIT_DOCKER_SOCKET` for the agent.
+ * docker
+ * containerd
+ * cri-o
+
+The agent discovers any running container communication with the container runtime daemon. You can configure a different container socket by setting the environment variable `STEADYBIT_EXTENSION_CONTAINER_SOCKET` for the agent.
 
 For each container the following attributes are provided:
 


### PR DESCRIPTION
### Motivation

Container extension public doc only mentions Docker runtime.

### What was done

Listed all 3 supported runtimes and updated the container runtime socket configuration text