### PR TITLE
docs(jvm): attack support matrix across Java & Spring Boot versions

### DIFF
--- a/actions/com.steadybit.extension_jvm.java-method-delay-attack/summary.mdx
+++ b/actions/com.steadybit.extension_jvm.java-method-delay-attack/summary.mdx
@@ -9,6 +9,10 @@ If the targeted method is overloaded, all overloaded variants will be affected.
 
 The delay is applied before the method executes.
 
+# Compatibility
+
+Verified on Java 8, 11, 17, 21 and 25 — on plain Java applications and on Spring Boot 2.7, 3.5 and 4.1.
+
 # Parameters
 
 | Parameter                      | Description                                                                             | Default |

--- a/actions/com.steadybit.extension_jvm.java-method-delay-attack/summary.mdx
+++ b/actions/com.steadybit.extension_jvm.java-method-delay-attack/summary.mdx
@@ -11,7 +11,7 @@ The delay is applied before the method executes.
 
 # Compatibility
 
-Verified on Java 8, 11, 17, 21 and 25 — on plain Java applications and on Spring Boot 2.7, 3.5 and 4.1.
+Verified on Java 8, 11, 17, 21 and 25 on any JVM application.
 
 # Parameters
 

--- a/actions/com.steadybit.extension_jvm.java-method-exception-attack/summary.mdx
+++ b/actions/com.steadybit.extension_jvm.java-method-exception-attack/summary.mdx
@@ -9,6 +9,10 @@ If the targeted method is overloaded, all overloaded variants will be affected.
 
 The exception is thrown before the method is executed, so the attacked method will not be executed.
 
+# Compatibility
+
+Verified on Java 8, 11, 17, 21 and 25 — on plain Java applications and on Spring Boot 2.7, 3.5 and 4.1.
+
 # Parameters
 
 | Parameter                      | Description                                                                             | Default |

--- a/actions/com.steadybit.extension_jvm.java-method-exception-attack/summary.mdx
+++ b/actions/com.steadybit.extension_jvm.java-method-exception-attack/summary.mdx
@@ -11,7 +11,7 @@ The exception is thrown before the method is executed, so the attacked method wi
 
 # Compatibility
 
-Verified on Java 8, 11, 17, 21 and 25 — on plain Java applications and on Spring Boot 2.7, 3.5 and 4.1.
+Verified on Java 8, 11, 17, 21 and 25 on any JVM application.
 
 # Parameters
 

--- a/actions/com.steadybit.extension_jvm.spring-httpclient-delay-attack/summary.mdx
+++ b/actions/com.steadybit.extension_jvm.spring-httpclient-delay-attack/summary.mdx
@@ -2,8 +2,6 @@
 
 Delays a response from a Spring `RestTemplate`, `WebClient` or `RestClient` by the given duration.
 
-`RestClient` is available from Spring Boot 3.2; all three clients are supported on every maintained Spring Boot line.
-
 # Details
 
 This attack only targets JVMs identified as Spring Application.
@@ -11,6 +9,10 @@ This attack only targets JVMs identified as Spring Application.
 # Use Cases
 
 * Understand how your services behave under slow network connections to other services
+
+# Compatibility
+
+Verified with Spring Boot 2.7, 3.5 and 4.1 for `RestTemplate`, `WebClient` and (Spring Boot 3.2+) `RestClient`.
 
 # Parameters
 

--- a/actions/com.steadybit.extension_jvm.spring-httpclient-delay-attack/summary.mdx
+++ b/actions/com.steadybit.extension_jvm.spring-httpclient-delay-attack/summary.mdx
@@ -1,6 +1,8 @@
 # Introduction
 
-Delays a response from a Spring `RestTemplate` or `WebClient` by the given duration.
+Delays a response from a Spring `RestTemplate`, `WebClient` or `RestClient` by the given duration.
+
+`RestClient` is available from Spring Boot 3.2; all three clients are supported on every maintained Spring Boot line.
 
 # Details
 

--- a/actions/com.steadybit.extension_jvm.spring-httpclient-status-attack/summary.mdx
+++ b/actions/com.steadybit.extension_jvm.spring-httpclient-status-attack/summary.mdx
@@ -1,12 +1,16 @@
 # Introduction
 
-Return the given status code from Spring `RestTemplate` or `WebClient` calls.
+Return the given status code from Spring `RestTemplate`, `WebClient` or `RestClient` calls.
 
 # Details
 
 This attack only targets JVMs identified as Spring Application.
 
 The original call is not executed.
+
+# Compatibility
+
+On Spring Framework 6+ (Spring Boot 3.x / 4.x) the status injection currently only takes effect for `WebClient`; for `RestTemplate` and `RestClient` the original call is still executed. Use `WebClient` to simulate HTTP-client failures on these versions. On Spring Boot 2.7 (Spring Framework 5) `RestTemplate` and `WebClient` are both supported.
 
 # Use Cases
 

--- a/actions/com.steadybit.extension_jvm.spring-httpclient-status-attack/summary.mdx
+++ b/actions/com.steadybit.extension_jvm.spring-httpclient-status-attack/summary.mdx
@@ -10,6 +10,8 @@ The original call is not executed.
 
 # Compatibility
 
+Verified with Spring Boot 2.7, 3.5 and 4.1.
+
 On Spring Framework 6+ (Spring Boot 3.x / 4.x) the status injection currently only takes effect for `WebClient`; for `RestTemplate` and `RestClient` the original call is still executed. Use `WebClient` to simulate HTTP-client failures on these versions. On Spring Boot 2.7 (Spring Framework 5) `RestTemplate` and `WebClient` are both supported.
 
 # Use Cases

--- a/actions/com.steadybit.extension_jvm.spring-jdbctemplate-delay-attack/summary.mdx
+++ b/actions/com.steadybit.extension_jvm.spring-jdbctemplate-delay-attack/summary.mdx
@@ -6,6 +6,10 @@ Delay a Spring JDBC Template response by the given duration.
 
 This attack only target JVMs identified as Spring Application.
 
+# Compatibility
+
+Verified with Spring Boot 2.7, 3.5 and 4.1, on the Java LTS releases each line supports (Java 8–17 for 2.7; 17–25 for 3.5 and 4.1).
+
 # Parameters
 
 | Parameter           | Description                                          | Default |

--- a/actions/com.steadybit.extension_jvm.spring-jdbctemplate-exception-attack/summary.mdx
+++ b/actions/com.steadybit.extension_jvm.spring-jdbctemplate-exception-attack/summary.mdx
@@ -6,6 +6,10 @@ Throw an exception in a Spring JDBC Template.
 
 This attack only target JVMs identified as Spring Application. The original call is not executed.
 
+# Compatibility
+
+Verified with Spring Boot 2.7, 3.5 and 4.1, on the Java LTS releases each line supports (Java 8–17 for 2.7; 17–25 for 3.5 and 4.1).
+
 # Parameters
 
 | Parameter           | Description                                                                  | Default |

--- a/actions/com.steadybit.extension_jvm.spring-mvc-delay-attack/summary.mdx
+++ b/actions/com.steadybit.extension_jvm.spring-mvc-delay-attack/summary.mdx
@@ -12,6 +12,10 @@ The delay is applied before the handler method is executed.
 
 * Understand how your services behave under pressure of latency
 
+# Compatibility
+
+Verified with Spring Boot 2.7, 3.5 and 4.1, on the Java LTS releases each line supports (Java 8–17 for 2.7; 17–25 for 3.5 and 4.1).
+
 # Parameters
 
 | Parameter       | Description                                                         | Default |

--- a/actions/com.steadybit.extension_jvm.spring-mvc-exception-attack/summary.mdx
+++ b/actions/com.steadybit.extension_jvm.spring-mvc-exception-attack/summary.mdx
@@ -8,6 +8,10 @@ This attack only target JVMs identified as Spring Application.
 
 The exception is thrown before the handler method is executed.
 
+# Compatibility
+
+Verified with Spring Boot 2.7, 3.5 and 4.1, on the Java LTS releases each line supports (Java 8–17 for 2.7; 17–25 for 3.5 and 4.1).
+
 # Parameters
 
 | Parameter           | Description                                                              | Default |

--- a/extensions/com.steadybit.extension_jvm/summary.mdx
+++ b/extensions/com.steadybit.extension_jvm/summary.mdx
@@ -6,15 +6,16 @@ With this extension you are able to attack your jvm / java based applications in
 
 The attacks are verified against the current Java LTS releases (8, 11, 17, 21, 25) and the maintained Spring Boot lines (2.7, 3.5, 4.1):
 
-| Attack | Plain Java | Spring Boot 2.7 | Spring Boot 3.5 | Spring Boot 4.1 |
-|--------|:----------:|:---------------:|:---------------:|:---------------:|
-| Java Method Delay / Exception | ✓ | ✓ | ✓ | ✓ |
-| Spring Controller Delay / Exception | — | ✓ | ✓ | ✓ |
-| Spring JDBC Template Delay / Exception | — | ✓ | ✓ | ✓ |
-| Spring HTTP Client Delay (RestTemplate, WebClient, RestClient¹) | — | ✓ | ✓ | ✓ |
-| Spring HTTP Client Status — WebClient | — | ✓ | ✓ | ✓ |
-| Spring HTTP Client Status — RestTemplate / RestClient¹ | — | ✓ | ✗² | ✗² |
+| Attack | Plain JVM | Boot 2.7 | Boot 3.5 | Boot 4.1 |
+|---|:---:|:---:|:---:|:---:|
+| Java Method Delay / Exception | yes | yes | yes | yes |
+| Spring Controller Delay / Exception | no | yes | yes | yes |
+| Spring JDBC Template Delay / Exception | no | yes | yes | yes |
+| Spring HTTP Client Delay | no | yes | yes | yes |
+| Spring HTTP Client Status (WebClient) | no | yes | yes | yes |
+| Spring HTTP Client Status (RestTemplate / RestClient) | no | yes | no | no |
 
-¹ `RestClient` was introduced in Spring Framework 6.1 (Spring Boot 3.2), so it is only available on Spring Boot 3.5 and 4.1.
+Notes:
 
-² On Spring Framework 6+ (Spring Boot 3.x / 4.x) the HTTP-client **status** injection does not currently take effect for the blocking clients (`RestTemplate` / `RestClient`) — the original call still executes. Use `WebClient` to simulate HTTP-client failures on these versions. The **delay** attack works for all three clients on every supported version.
+- The HTTP-client attacks cover `RestTemplate`, `WebClient` and — from Spring Boot 3.2 — `RestClient`. The **delay** attack works for all three clients on every supported version.
+- The HTTP-client **status** attack does not currently take effect for the blocking clients (`RestTemplate` / `RestClient`) on Spring Framework 6+ (Spring Boot 3.x / 4.x) — the original call still executes. Use `WebClient` to simulate HTTP-client failures on these versions.

--- a/extensions/com.steadybit.extension_jvm/summary.mdx
+++ b/extensions/com.steadybit.extension_jvm/summary.mdx
@@ -1,3 +1,20 @@
 # Introduction
 
 With this extension you are able to attack your jvm / java based applications in different ways like delay endpoints / http clients / jdbc connections, inject exceptions and modify http status codes.
+
+# Supported versions
+
+The attacks are verified against the current Java LTS releases (8, 11, 17, 21, 25) and the maintained Spring Boot lines (2.7, 3.5, 4.1):
+
+| Attack | Plain Java | Spring Boot 2.7 | Spring Boot 3.5 | Spring Boot 4.1 |
+|--------|:----------:|:---------------:|:---------------:|:---------------:|
+| Java Method Delay / Exception | ✓ | ✓ | ✓ | ✓ |
+| Spring Controller Delay / Exception | — | ✓ | ✓ | ✓ |
+| Spring JDBC Template Delay / Exception | — | ✓ | ✓ | ✓ |
+| Spring HTTP Client Delay (RestTemplate, WebClient, RestClient¹) | — | ✓ | ✓ | ✓ |
+| Spring HTTP Client Status — WebClient | — | ✓ | ✓ | ✓ |
+| Spring HTTP Client Status — RestTemplate / RestClient¹ | — | ✓ | ✗² | ✗² |
+
+¹ `RestClient` was introduced in Spring Framework 6.1 (Spring Boot 3.2), so it is only available on Spring Boot 3.5 and 4.1.
+
+² On Spring Framework 6+ (Spring Boot 3.x / 4.x) the HTTP-client **status** injection does not currently take effect for the blocking clients (`RestTemplate` / `RestClient`) — the original call still executes. Use `WebClient` to simulate HTTP-client failures on these versions. The **delay** attack works for all three clients on every supported version.


### PR DESCRIPTION
Documents which JVM-extension attacks are supported on which Java LTS and Spring Boot versions, so Hub users can see coverage at a glance.

## What

- **Extension summary** (`com.steadybit.extension_jvm`): adds a **Supported versions** matrix — verified against Java LTS **8, 11, 17, 21, 25** and Spring Boot **2.7, 3.5, 4.1**.
- **HTTP-client actions**: note that the clients covered are `RestTemplate`, `WebClient`, and (from Spring Boot 3.2) `RestClient`, and call out one real limitation on the **status** attack.

## The support matrix

| Attack | Plain Java | Boot 2.7 | Boot 3.5 | Boot 4.1 |
|--------|:--:|:--:|:--:|:--:|
| Java Method Delay / Exception | ✓ | ✓ | ✓ | ✓ |
| Spring Controller Delay / Exception | — | ✓ | ✓ | ✓ |
| Spring JDBC Template Delay / Exception | — | ✓ | ✓ | ✓ |
| Spring HTTP Client Delay (RestTemplate/WebClient/RestClient) | — | ✓ | ✓ | ✓ |
| Spring HTTP Client Status — WebClient | — | ✓ | ✓ | ✓ |
| Spring HTTP Client Status — RestTemplate / RestClient | — | ✓ | ✗ | ✗ |

The one gap: on Spring Framework 6+ (Boot 3.x/4.x) the HTTP-client **status** injection does not take effect for the blocking clients (`RestTemplate`/`RestClient`) — WebClient works everywhere, and all **delay** variants work everywhere.

## Source

Generated and verified by the on-demand attack-support-matrix suite added to `steadybit/extension-jvm` (BM-13107): full-grid CI run https://github.com/steadybit/extension-jvm/actions/runs/29912665462 (see also extension-jvm PR #424). The RestTemplate/RestClient status gap on Framework 6+ is being tracked for a fix.