### PR TITLE
docs: align network attack docs with portless-protocol (ICMP) support

### DIFF
--- a/actions/com.steadybit.extension_container.network_bandwidth/summary.mdx
+++ b/actions/com.steadybit.extension_container.network_bandwidth/summary.mdx
@@ -6,8 +6,6 @@ Limits container network bandwidth for all matching egress traffic.
 
 _Note:_ If you are going to attack containers using network attacks, **all containers in the target's linux network namespace** (e.g. all containers belonging to the same Kubernetes Pod) will be affected. In case you want to target the traffic of a single container in the namespace you can for example use the port parameter to limit the blast radius.
 
-This attack affects network traffic for protocols that use port numbers (e.g., TCP, UDP). Protocols like ICMP, which do not use ports, remain unaffected and will continue to function normally.
-
 # Use Cases
 
 * Understand your service's performance under load

--- a/actions/com.steadybit.extension_container.network_blackhole/summary.mdx
+++ b/actions/com.steadybit.extension_container.network_blackhole/summary.mdx
@@ -6,8 +6,6 @@ Drops all network traffic (IN/OUT/FORWARDED).
 
 _Note:_ If you are going to attack containers using network attacks, **all containers in the target's linux network namespace** (e.g. all containers belonging to the same Kubernetes Pod) will be affected. In case you want to target the traffic of a single container in the namespace you can for example use the port parameter to limit the blast radius.
 
-This attack affects network traffic for protocols that use port numbers (e.g., TCP, UDP). Protocols like ICMP, which do not use ports, remain unaffected and will continue to function normally.
-
 # Use Cases
 
 * Understand how your services behave under network outages

--- a/actions/com.steadybit.extension_container.network_delay/summary.mdx
+++ b/actions/com.steadybit.extension_container.network_delay/summary.mdx
@@ -4,7 +4,7 @@ Inject latency into all matching egress traffic.
 
 # Details
 
-The network delay operates at the ip level and affects single packets (network layer, level 3). Thus, it works for UDP and TCP traffic, and you may encounter HTTP requests that are delayed by a multiple of the specified delay.
+The network delay operates at the ip level and affects single packets (network layer, level 3). Thus, you may encounter HTTP requests that are delayed by a multiple of the specified delay.
 
 In this example the traffic is delayed by 500ms. If you tap the wire (using tcpdump) and feed it into Wireshark it looks like shown in the image above.
 

--- a/actions/com.steadybit.extension_container.network_package_corruption/summary.mdx
+++ b/actions/com.steadybit.extension_container.network_package_corruption/summary.mdx
@@ -6,8 +6,6 @@ Inject corrupt packets by introducing single bit error at a random offset into e
 
 _Note:_ If you are going to attack containers using network attacks, **all containers in the target's namespace** (e.g. all containers belonging to the same Kubernetes Pod) will be affected. In case you want to target the traffic of a single container in the namespace you can for example use the port parameter to limit the blast radius.
 
-This attack affects network traffic for protocols that use port numbers (e.g., TCP, UDP). Protocols like ICMP, which do not use ports, remain unaffected and will continue to function normally.
-
 # Use Cases
 
 * Testing network resilience to bit errors

--- a/actions/com.steadybit.extension_container.network_package_loss/summary.mdx
+++ b/actions/com.steadybit.extension_container.network_package_loss/summary.mdx
@@ -6,8 +6,6 @@ Cause packet loss for matching outgoing network traffic.
 
 _Note:_ If you are going to attack containers using network attacks, **all containers in the target's linux network namespace** (e.g. all containers belonging to the same Kubernetes Pod) will be affected. In case you want to target the traffic of a single container in the namespace you can for example use the port parameter to limit the blast radius.
 
-This attack affects network traffic for protocols that use port numbers (e.g., TCP, UDP). Protocols like ICMP, which do not use ports, remain unaffected and will continue to function normally.
-
 # Use Cases
 
 * Understand how your services behave under specific / flaky network conditions

--- a/actions/com.steadybit.extension_host.network_bandwidth/summary.mdx
+++ b/actions/com.steadybit.extension_host.network_bandwidth/summary.mdx
@@ -6,10 +6,6 @@ Limits bandwidth for all matching egress network traffic.
 
 If you are not using our container images for the extension, you need install the `tc` (from the iproute2 package) tool to use the attack.
 
-# Restrictions
-
-This attack affects network traffic for protocols that use port numbers (e.g., TCP, UDP). Protocols like ICMP, which do not use ports, remain unaffected and will continue to function normally.
-
 # Use Cases
 
 * Understand your service's performance under load

--- a/actions/com.steadybit.extension_host.network_blackhole/summary.mdx
+++ b/actions/com.steadybit.extension_host.network_blackhole/summary.mdx
@@ -8,7 +8,6 @@ If you are not using our container images for the extension, the attack requires
 
 # Restrictions
 
-- This attack affects network traffic for protocols that use port numbers (e.g., TCP, UDP). Protocols like ICMP, which do not use ports, remain unaffected and will continue to function normally.
 - This attack is not supported on hosts using Cilium.
 
 # Use Cases

--- a/actions/com.steadybit.extension_host.network_delay/summary.mdx
+++ b/actions/com.steadybit.extension_host.network_delay/summary.mdx
@@ -8,7 +8,7 @@ If you are not using our container images for the extension, you need install th
 
 # Details
 
-The network delay operates at the ip level and affects single packets (network layer, level 3). Thus, it works for UDP and TCP traffic, and you may encounter HTTP requests that are delayed by a multiple of the specified delay.
+The network delay operates at the ip level and affects single packets (network layer, level 3). Thus, you may encounter HTTP requests that are delayed by a multiple of the specified delay.
 
 In this example the traffic is delayed by 500ms. If you tap the wire (using tcpdump) and feed it into Wireshark it looks like shown in the image above.
 

--- a/actions/com.steadybit.extension_host.network_package_corruption/summary.mdx
+++ b/actions/com.steadybit.extension_host.network_package_corruption/summary.mdx
@@ -6,10 +6,6 @@ Inject corrupt packets by introducing single bit error at a random offset into e
 
 If you are not using our container images for the extension, you need install the `tc` (from the iproute2 package) tool to use the attack.
 
-# Restrictions
-
-This attack affects network traffic for protocols that use port numbers (e.g., TCP, UDP). Protocols like ICMP, which do not use ports, remain unaffected and will continue to function normally.
-
 # Use Cases
 
 * Testing network resilience to bit errors

--- a/actions/com.steadybit.extension_host.network_package_loss/summary.mdx
+++ b/actions/com.steadybit.extension_host.network_package_loss/summary.mdx
@@ -6,10 +6,6 @@ Cause packet loss for matching outgoing network traffic.
 
 If you are not using our container images for the extension, you need install the `tc` (from the iproute2 package) tool to use the attack.
 
-# Restrictions
-
-This attack affects network traffic for protocols that use port numbers (e.g., TCP, UDP). Protocols like ICMP, which do not use ports, remain unaffected and will continue to function normally.
-
 # Use Cases
 
 * Understand how your services behave under specific / flaky network conditions

--- a/actions/com.steadybit.extension_host_windows.network_bandwidth/summary.mdx
+++ b/actions/com.steadybit.extension_host_windows.network_bandwidth/summary.mdx
@@ -12,6 +12,10 @@ This attack limits the bandwidth of outgoing network connections matching the co
 
 Without specifying a host or ip restriction, the attack would affect all traffic and may lead to broken communication between the Steadybit agent and platform. Hence, either the hostname or IP parameter is required.
 
+# Restrictions
+
+This attack uses Windows QoS policies and therefore only affects network traffic for protocols that use port numbers (e.g., TCP, UDP). Protocols like ICMP, which do not use ports, remain unaffected and will continue to function normally.
+
 # Use Cases
 
 * Understand your service's performance under load


### PR DESCRIPTION
## What

Aligns the Reliability Hub docs for the network attacks with the portless-protocol (ICMP) fix (BM 13054, extension-host / extension-container / extension-host-windows + action_kit_commons v1.10.4).

### Removed the "ICMP unaffected" note (behavior now affects ICMP)
Linux **host** and **container** attacks that previously stated *"…protocols like ICMP, which do not use ports, remain unaffected…"*:
- `network_blackhole` (kept the unrelated "not supported on Cilium" note)
- `network_bandwidth`
- `network_package_corruption`
- `network_package_loss`

Blackhole now affects ICMP after the fix; bandwidth/loss/corruption run through the `tc` u32 zero-mask path which already matches portless protocols.

### Reworded `network_delay` (host + container)
Dropped the explicit "it works for UDP and TCP traffic" phrasing, which is no longer accurate (delay also affects ICMP).

### Added an ICMP-limitation note to Windows `network_bandwidth`
Unlike the other Windows network attacks (which use WinDivert and now affect ICMP), Windows bandwidth is implemented with Windows QoS policies, which cannot match portless protocols. It now explicitly documents that ICMP is unaffected.

### Unchanged (correct as-is)
- `network_tcp_reset` — inherently TCP-only.
- Windows blackhole/delay/loss/corruption — never carried the restriction note and now affect ICMP.

Ref: BusinessMap 13054
