### PR TITLE
docs(jvm): http-client status now works on all clients on Spring 6+

### DIFF
--- a/actions/com.steadybit.extension_jvm.spring-httpclient-status-attack/description.yml
+++ b/actions/com.steadybit.extension_jvm.spring-httpclient-status-attack/description.yml
@@ -1,7 +1,7 @@
 ---
 id: com.steadybit.extension_jvm.spring-httpclient-status-attack
 label: Spring Http Client Status
-description: Returns the given status code for a RestTemplate or WebClient call. The original call is not executed.
+description: Returns the given status code for a RestTemplate, WebClient or RestClient call. The original call is not executed.
 icon: <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><g clip-path="url(#icon-attack-network-delay_svg__clip0)" fill-rule="evenodd" clip-rule="evenodd" fill="currentColor"><path d="M17.25 12a5.25 5.25 0 100 10.5 5.25 5.25 0 000-10.5zm-6.75 5.25a6.75 6.75 0 1113.5 0 6.75 6.75 0 01-13.5 0z"/><path d="M17.25 13.849a.75.75 0 01.75.75V16.5h1.902a.75.75 0 010 1.5H17.25a.75.75 0 01-.75-.75v-2.651a.75.75 0 01.75-.75z"/><path d="M15.367 2.054a10.501 10.501 0 10-4.773 20.353.75.75 0 11-.2 1.486 12 12 0 1113.501-13.487.75.75 0 01-1.486.2 10.502 10.502 0 00-7.042-8.552z"/><path d="M9.711.46a.75.75 0 01.198 1.041C8.507 3.56 7.499 7.441 7.499 12s1.008 8.442 2.41 10.499a.75.75 0 01-1.24.844c-1.64-2.407-2.67-6.636-2.67-11.343S7.03 3.065 8.67.657A.75.75 0 019.71.459z"/><path d="M.025 11.25a.75.75 0 01.75-.75h9.523a.75.75 0 010 1.5H.775a.75.75 0 01-.75-.75zm2.224-6a.75.75 0 01.75-.75h18A.75.75 0 0121 6H3a.75.75 0 01-.75-.75zm-.951 12a.75.75 0 01.75-.75H8.25a.75.75 0 010 1.5H2.048a.75.75 0 01-.75-.75z"/><path d="M14.329.434a.75.75 0 011.027.263 17.733 17.733 0 012.402 7.451.75.75 0 01-1.494.134 16.233 16.233 0 00-2.199-6.821.75.75 0 01.264-1.027z"/></g><defs><clipPath id="icon-attack-network-delay_svg__clip0"><path fill="currentColor" d="M0 0h24v24H0z"/></clipPath></defs></svg>
 kind: attack
 targetType: com.steadybit.extension_jvm.jvm-instance

--- a/actions/com.steadybit.extension_jvm.spring-httpclient-status-attack/summary.mdx
+++ b/actions/com.steadybit.extension_jvm.spring-httpclient-status-attack/summary.mdx
@@ -12,7 +12,7 @@ The original call is not executed.
 
 Verified with Spring Boot 2.7, 3.5 and 4.1.
 
-On Spring Framework 6+ (Spring Boot 3.x / 4.x) the status injection currently only takes effect for `WebClient`; for `RestTemplate` and `RestClient` the original call is still executed. Use `WebClient` to simulate HTTP-client failures on these versions. On Spring Boot 2.7 (Spring Framework 5) `RestTemplate` and `WebClient` are both supported.
+The status injection takes effect for `RestTemplate`, `WebClient` and `RestClient`.
 
 # Use Cases
 

--- a/extensions/com.steadybit.extension_jvm/summary.mdx
+++ b/extensions/com.steadybit.extension_jvm/summary.mdx
@@ -12,10 +12,8 @@ The attacks are verified against the current Java LTS releases (8, 11, 17, 21, 2
 | Spring Controller Delay / Exception | no | yes | yes | yes |
 | Spring JDBC Template Delay / Exception | no | yes | yes | yes |
 | Spring HTTP Client Delay | no | yes | yes | yes |
-| Spring HTTP Client Status (WebClient) | no | yes | yes | yes |
-| Spring HTTP Client Status (RestTemplate / RestClient) | no | yes | no | no |
+| Spring HTTP Client Status | no | yes | yes | yes |
 
 Notes:
 
-- The HTTP-client attacks cover `RestTemplate`, `WebClient` and — from Spring Boot 3.2 — `RestClient`. The **delay** attack works for all three clients on every supported version.
-- The HTTP-client **status** attack does not currently take effect for the blocking clients (`RestTemplate` / `RestClient`) on Spring Framework 6+ (Spring Boot 3.x / 4.x) — the original call still executes. Use `WebClient` to simulate HTTP-client failures on these versions.
+- The HTTP-client **delay** and **status** attacks both cover `RestTemplate`, `WebClient` and `RestClient`.


### PR DESCRIPTION
The JVM extension's **HTTP-client status** attack now takes effect for `RestTemplate`, `WebClient` and `RestClient` on **Spring Framework 6+** (Spring Boot 3.x / 4.x) — the previous limitation (blocking clients only worked on Spring 5) has been fixed in the extension.

Verified by the attack support matrix across Java LTS 8–25 × Spring Boot 2.7 / 3.5 / 4.1: `spring-httpclient-status[resttemplate|webclient|restclient]` is green on every applicable cell.

## Changes
- **Extension support matrix**: collapse the two split `Spring HTTP Client Status (WebClient)` / `(RestTemplate / RestClient)` rows into a single `Spring HTTP Client Status` row (supported on Boot 2.7 / 3.5 / 4.1), and drop the WebClient-only limitation note.
- **Action `Compatibility`**: replace the "only `WebClient` on Spring 6+" caveat with "all three clients, including Spring 6+".
- **Action description**: mention `RestClient` alongside `RestTemplate` / `WebClient`.